### PR TITLE
Use `TryFrom` and Rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   - /-release$/
 
 rust:
-- 1.30.0
+- 1.34.0
 
 env:
   global:
@@ -23,9 +23,9 @@ dist: trusty
 
 install:
 - cargo deadlinks -V | grep $DEADLINKS_VERS || cargo install cargo-deadlinks --vers $DEADLINKS_VERS --force
-- rustup component add rustfmt-preview
+- rustup component add rustfmt
 - rustfmt -V
-- rustup component add clippy-preview
+- rustup component add clippy
 - cargo clippy -V
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- Use 2018 Rust edition.
+- Use `TryFrom` trait, which was stabilized in Rust v1.34.
+
 ## 0.1.1 - 2018-11-30
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hex-buffer-serde"
-version = "0.1.1"
+version = "0.2.0"
+edition = "2018"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
 readme = "README.md"
 license = "Apache-2.0"
@@ -25,4 +26,4 @@ serde_json = "1.0"
 serde_cbor = "0.9.0"
 bincode = "1.0"
 rand = "0.5.5"
-ed25519-dalek = { version = "=1.0.0-pre.0", features = ["serde", "sha2"] }
+ed25519 = { version = "=1.0.0-pre.1", package = "ed25519-dalek", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,11 @@ travis-ci = { repository = "slowli/hex-buffer-serde" }
 [dependencies]
 serde = "1.0"
 hex = "0.3.2"
-failure = "0.1.3"
-failure_derive = "0.1.3"
 
 [dev-dependencies]
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_cbor = "0.9.0"
 bincode = "1.0"
-rand = "0.5.5"
+rand = "0.6.5"
 ed25519 = { version = "=1.0.0-pre.1", package = "ed25519-dalek", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis Build Status](https://img.shields.io/travis/com/slowli/hex-buffer-serde/master.svg?label=Linux%20Build)](https://travis-ci.com/slowli/hex-buffer-serde) 
 [![License: Apache-2.0](https://img.shields.io/github/license/slowli/hex-buffer-serde.svg)](https://github.com/slowli/hex-buffer-serde/blob/master/LICENSE)
-![rust 1.30.0+ required](https://img.shields.io/badge/rust-1.30.0+-blue.svg?label=Required%20Rust)
+![rust 1.34.0+ required](https://img.shields.io/badge/rust-1.34.0+-blue.svg?label=Required%20Rust)
 
 **Documentation:** [![Docs.rs](https://docs.rs/hex-buffer-serde/badge.svg)](https://docs.rs/hex-buffer-serde/) 
 [![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/hex-buffer-serde/hex_buffer_serde/)

--- a/examples/ed25519_dalek.rs
+++ b/examples/ed25519_dalek.rs
@@ -15,18 +15,9 @@
 //! Example demonstrating how to use the crate with external types which don't implement
 //! any "useful" traits (e.g., `AsRef<[u8]>` or `FromHex`).
 
-extern crate ed25519_dalek as ed25519;
-extern crate hex;
-extern crate rand;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
-extern crate hex_buffer_serde;
-extern crate serde_json;
-
-use ed25519::{ExpandedSecretKey, PublicKey, SecretKey};
+use ed25519::{PublicKey, SecretKey};
 use rand::thread_rng;
+use serde_derive::*;
 
 use std::borrow::Cow;
 
@@ -55,8 +46,7 @@ struct SomeData {
 
 fn main() {
     let secret_key = SecretKey::generate(&mut thread_rng());
-    let secret_key: ExpandedSecretKey = (&secret_key).into();
-    let public_key: PublicKey = secret_key.into();
+    let public_key: PublicKey = (&secret_key).into();
 
     println!("Key hex: {}", hex::encode(public_key.as_bytes()));
 


### PR DESCRIPTION
The latest stable version of Rust has stabilized `TryFrom` trait, which allows to simplify code.