### PR TITLE
Fix clippy lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,11 +90,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Run example
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example ed25519_dalek
+          args: --lib
 
   build-nostd:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron: '30 3 * * FRI'
 
 env:
   # Minimum supported Rust version.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example ed25519_dalek --all-features
+          args: --example ed25519 --all-features
 
       - name: Compile WASM
         run: (cd wasm; wasm-pack build --target nodejs)
@@ -90,7 +90,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib
+      - name: Run example
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example ed25519
 
   build-nostd:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Minimum supported Rust version.
-  msrv: 1.41.0
+  msrv: 1.46.0
   # Nightly Rust toolchain for no-std build.
   nightly: nightly-2021-04-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ serde_json = "1.0"
 serde_cbor = "0.11.1"
 bincode = "1.3.1"
 doc-comment = "0.3.3"
-ed25519 = { version = "1.0.1", package = "ed25519-dalek", features = ["serde"] }
+ed25519-compact = "0.1.9"
 version-sync = "0.9.1"
 
 [[example]]
-name = "ed25519_dalek"
-path = "examples/ed25519_dalek.rs"
+name = "ed25519"
+path = "examples/ed25519.rs"
 required-features = ["alloc"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/slowli/hex-buffer-serde/workflows/Rust/badge.svg?branch=master)](https://github.com/slowli/hex-buffer-serde/actions) 
 [![License: Apache-2.0](https://img.shields.io/github/license/slowli/hex-buffer-serde.svg)](https://github.com/slowli/hex-buffer-serde/blob/master/LICENSE)
-![rust 1.41.0+ required](https://img.shields.io/badge/rust-1.41.0+-blue.svg?label=Required%20Rust)
+![rust 1.46.0+ required](https://img.shields.io/badge/rust-1.46.0+-blue.svg?label=Required%20Rust)
 
 **Documentation:** [![Docs.rs](https://docs.rs/hex-buffer-serde/badge.svg)](https://docs.rs/hex-buffer-serde/) 
 [![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/hex-buffer-serde/hex_buffer_serde/)

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -7,7 +7,7 @@
 
 extern crate alloc;
 
-use ed25519::{PublicKey, SecretKey};
+use ed25519_compact::PublicKey;
 use serde_derive::*;
 
 use alloc::{
@@ -20,34 +20,30 @@ use hex_buffer_serde::Hex;
 struct PublicKeyHex(());
 
 impl Hex<PublicKey> for PublicKeyHex {
-    type Error = ed25519::SignatureError;
+    type Error = ed25519_compact::Error;
 
     fn create_bytes(value: &PublicKey) -> Cow<'_, [u8]> {
-        Cow::Borrowed(&*value.as_bytes())
+        Cow::Borrowed(&value[..])
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<PublicKey, Self::Error> {
-        PublicKey::from_bytes(bytes)
+        PublicKey::from_slice(bytes)
     }
 }
 
 #[derive(Serialize, Deserialize)]
 struct SomeData {
-    // Note that we have enabled `serde` feature in `Cargo.toml`. Thus,
-    // `PublicKey` implements `Serialize` / `Deserialize`, but not in the way we want
-    // (the value is just written as an array of separate bytes).
     #[serde(with = "PublicKeyHex")]
     public_key: PublicKey,
     name: Option<String>,
 }
 
 fn main() {
-    let secret_key =
-        hex::decode("9e55d1e1aa1f455b8baad9fdf975503655f8b359d542fa7e4ce84106d625b352").unwrap();
-    let secret_key = SecretKey::from_bytes(&secret_key).unwrap();
-    let public_key: PublicKey = (&secret_key).into();
+    let public_key =
+        hex::decode("06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075").unwrap();
+    let public_key = PublicKey::from_slice(&public_key).unwrap();
 
-    let key_hex = hex::encode(public_key.as_bytes());
+    let key_hex = hex::encode(&public_key[..]);
 
     let data = SomeData {
         public_key,

--- a/src/const_len.rs
+++ b/src/const_len.rs
@@ -261,18 +261,18 @@ mod tests {
 
     #[test]
     fn custom_type() {
-        use ed25519::PublicKey;
+        use ed25519_compact::PublicKey;
 
         struct PublicKeyHex(());
         impl ConstHex<PublicKey, 32> for PublicKeyHex {
-            type Error = ed25519::SignatureError;
+            type Error = ed25519_compact::Error;
 
             fn create_bytes(pk: &PublicKey) -> [u8; 32] {
-                pk.to_bytes()
+                **pk
             }
 
             fn from_bytes(bytes: [u8; 32]) -> Result<PublicKey, Self::Error> {
-                PublicKey::from_bytes(&bytes)
+                PublicKey::from_slice(&bytes)
             }
         }
 
@@ -286,7 +286,7 @@ mod tests {
             "public_key": "06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075",
         });
         let holder: Holder = serde_json::from_value(json).unwrap();
-        assert_eq!(holder.public_key.as_bytes()[0], 6);
+        assert_eq!(holder.public_key[0], 6);
 
         let bogus_json = serde_json::json!({
             "public_key": "06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f6111507",

--- a/src/const_len.rs
+++ b/src/const_len.rs
@@ -122,7 +122,7 @@ pub trait ConstHex<T, const N: usize> {
             // ^ `unwrap` is safe: the length is statically correct.
             serializer.serialize_str(unsafe {
                 // SAFETY: hex output is always valid UTF-8.
-                str::from_utf8_unchecked(&hex_slice)
+                str::from_utf8_unchecked(hex_slice)
             })
         } else {
             serializer.serialize_bytes(value.as_ref())


### PR DESCRIPTION
Rust 1.54 has introduced a new clippy lint, which is now fixed.